### PR TITLE
Add handling for different types of payload in get_payload_vcs_branch method

### DIFF
--- a/inc/api/class-webhook-api.php
+++ b/inc/api/class-webhook-api.php
@@ -522,6 +522,13 @@ class Webhook_API {
 	}
 
 	protected function get_payload_vcs_branch( $payload ) {
+
+		// Ensure we have an array to work with
+		$payload = is_string($payload) ? json_decode($payload, true) : $payload;
+		if (!is_array($payload)) {
+			return false;
+		}
+		
 		$branch = false;
 
 		if (


### PR DESCRIPTION
Fixes errors caused by different payload types.

With the current version, I get an error message saying $payload is a string and an array is expected. If I paste the old code removed in 2248d4e6bcfe6f70dcc0f1e421ee314baac8c1d2, I get an error message saying $payload is an array and is expected as a string.

So, it seems the method is being called multiple times in the same request, once with a JSON string and once with an array.

I haven't been able to figure out why it's being called with different payload types. Perhaps this problem should actually be addressed differently, but this is a quick fix.