### PR TITLE
Fix "Requires License" typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,33 @@
 # UpdatePulse Server - Run your own update server
 
-* [UpdatePulse Server - Run your own update server](#updatepulse-server---run-your-own-update-server)
-	* [Introduction](#introduction)
-		* [Overview](#overview)
-		* [Special Thanks](#special-thanks)
-		* [Compatibility](#compatibility)
-		* [Screenshots](#screenshots)
-			* [Packages Overview](#packages-overview)
-			* [Version Control Systems](#version-control-systems)
-			* [Licenses](#licenses)
-			* [API \& Webhooks](#api--webhooks)
-			* [Client - plugin screens](#client---plugin-screens)
-			* [Client - theme screens](#client---theme-screens)
-			* [Client - updates screen](#client---updates-screen)
-	* [User Interface](#user-interface)
-		* [Packages Overview](#packages-overview-1)
-		* [Version Control Systems](#version-control-systems-1)
-		* [Licenses](#licenses-1)
-		* [API \& Webhooks](#api--webhooks-1)
-	* [Performances](#performances)
-		* [Benchmark](#benchmark)
-		* [Update API](#update-api)
-		* [Public License API](#public-license-api)
-	* [Help](#help)
-		* [Registering packages with a Version Control System](#registering-packages-with-a-version-control-system)
-		* [Provide updates with UpdatePulse Server - packages requirements](#provide-updates-with-updatepulse-server---packages-requirements)
-		* [Scheduled tasks optimisation](#scheduled-tasks-optimisation)
-		* [Requests optimisation](#requests-optimisation)
-		* [More help...](#more-help)
+- [UpdatePulse Server - Run your own update server](#updatepulse-server---run-your-own-update-server)
+	- [Introduction](#introduction)
+		- [Overview](#overview)
+		- [Special Thanks](#special-thanks)
+		- [Compatibility](#compatibility)
+		- [Screenshots](#screenshots)
+			- [Packages Overview](#packages-overview)
+			- [Version Control Systems](#version-control-systems)
+			- [Licenses](#licenses)
+			- [API \& Webhooks](#api--webhooks)
+			- [Client - plugin screens](#client---plugin-screens)
+			- [Client - theme screens](#client---theme-screens)
+			- [Client - updates screen](#client---updates-screen)
+	- [User Interface](#user-interface)
+		- [Packages Overview](#packages-overview-1)
+		- [Version Control Systems](#version-control-systems-1)
+		- [Licenses](#licenses-1)
+		- [API \& Webhooks](#api--webhooks-1)
+	- [Performances](#performances)
+		- [Benchmark](#benchmark)
+		- [Update API](#update-api)
+		- [Public License API](#public-license-api)
+	- [Help](#help)
+		- [Registering packages with a Version Control System](#registering-packages-with-a-version-control-system)
+		- [Provide updates with UpdatePulse Server - packages requirements](#provide-updates-with-updatepulse-server---packages-requirements)
+		- [Scheduled tasks optimisation](#scheduled-tasks-optimisation)
+		- [Requests optimisation](#requests-optimisation)
+		- [More help...](#more-help)
 
 
 Developer documentation:
@@ -168,7 +168,7 @@ In case Webhooks are not used, the following actions are available to forcefully
 ### Licenses
 
 This tab allows administrators to:
-- Entirely enable/disable package licenses. **It affects all the packages with a "Requires License" license status delivered by UpdatePulse Server.**
+- Entirely enable/disable package licenses. **It affects all the packages with a "Require License" license status delivered by UpdatePulse Server.**
 - View the list of licenses currently stored by UpdatePulse Server, with License Key, Registered Email, Status, Package Type (Plugin or Theme), Package Slug, Creation Date, Expiration Date, ID
 - Add a license
 - Edit a license

--- a/inc/templates/admin/plugin-licenses-page.php
+++ b/inc/templates/admin/plugin-licenses-page.php
@@ -186,7 +186,7 @@
 					<p class="description">
 						<?php esc_html_e( 'Check to activate license checking when delivering package updates.', 'updatepulse-server' ); ?>
 						<br>
-						<strong><?php esc_html_e( 'It affects all the packages with a "Requires License" license status delivered by this installation of UpdatePulse Server.', 'updatepulse-server' ); ?></strong>
+						<strong><?php esc_html_e( 'It affects all the packages with a "Require License" license status delivered by this installation of UpdatePulse Server.', 'updatepulse-server' ); ?></strong>
 					</p>
 				</td>
 			</tr>

--- a/languages/updatepulse-server.pot
+++ b/languages/updatepulse-server.pot
@@ -1051,7 +1051,7 @@ msgstr ""
 
 #: inc/templates/admin/plugin-licenses-page.php:189
 msgid ""
-"It affects all the packages with a \"Requires License\" license status "
+"It affects all the packages with a \"Require License\" license status "
 "delivered by this installation of UpdatePulse Server."
 msgstr ""
 


### PR DESCRIPTION
In the documentation, it lists the header used to indicate that a plugin or theme requires a license is "Requires License" when it is actually "Require License" as indicated below:

https://github.com/Anyape/updatepulse-server/blob/65cca42ed00a62c7b6727984de434243eeab9a58/lib/anyape-package-parser/package-parser.php#L499

This update fixes that typo in the documentation.

_**Note:** My IDE automatically wants to swap the "*" list characters with "-" in README.md. I'm having difficulty fixing this internally because there are other lists further down in the readme which use the "-" character. If this is a problem, let me know._